### PR TITLE
Update README for correct nvim version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
 
 ## Requirements
 
-- Neovim 0.7.0 or higher
+- Neovim 0.11.0 or higher
 - Git installed and accessible in path
 - A Git repository
 


### PR DESCRIPTION
While testing the plugin on an older setup (0.10.4), I found a nilptr caused by the `vim.fs.relpath` [invocation](https://github.com/afonsofrancof/worktrees.nvim/blob/main/lua/worktrees.lua#L52). AFAIK this is a fairly recent API introduced in [0.11](https://github.com/neovim/neovim/blob/master/runtime/doc/news-0.11.txt#L305)

```
Error executing vim.schedule lua callback: .../.local/share/nvim/lazy/worktrees.nvim/lua/worktrees.lua:52: attempt to call fiel
d 'relpath' (a nil value)
stack traceback:
        .../.local/share/nvim/lazy/worktrees.nvim/lua/worktrees.lua:52: in function 'get_current_file_in_other_worktree'
        .../.local/share/nvim/lazy/worktrees.nvim/lua/worktrees.lua:102: in function 'switch_worktree'
        .../.local/share/nvim/lazy/worktrees.nvim/lua/worktrees.lua:307: in function 'on_choice'
        ...share/nvim/lazy/snacks.nvim/lua/snacks/picker/select.lua:49: in function <...share/nvim/lazy/snacks.nvim/lua/snacks/
picker/select.lua:48>
```