### PR TITLE
feat(create): allow switching to new worktree

### DIFF
--- a/lua/worktrees.lua
+++ b/lua/worktrees.lua
@@ -55,7 +55,7 @@ local function get_current_file_in_other_worktree(target_worktree_path)
     local target_file = vim.fs.joinpath(target_worktree_path, relative_path)
 
     -- Check if the file exists in the target worktree
-    local stat = vim.loop.fs_stat(target_file)
+    local stat = vim.uv.fs_stat(target_file)
     if stat then
         return target_file
     else
@@ -77,7 +77,7 @@ M.utils.switch_worktree = function(path)
     local normalized_path = vim.fs.normalize(path)
 
     -- Check if the path exists
-    local stat = vim.loop.fs_stat(normalized_path)
+    local stat = vim.uv.fs_stat(normalized_path)
     if not stat or stat.type ~= "directory" then
         vim.notify("Worktree path does not exist: " .. path, vim.log.levels.ERROR)
         return false

--- a/lua/worktrees.lua
+++ b/lua/worktrees.lua
@@ -119,7 +119,7 @@ M.utils.switch_worktree = function(path)
 end
 
 -- Create a new worktree
-M.utils.create_worktree = function(path, branch)
+M.utils.create_worktree = function(path, branch, switch)
     if not branch or branch == "" then
         vim.notify("Branch name is required", vim.log.levels.ERROR)
         return false
@@ -172,7 +172,7 @@ M.utils.create_worktree = function(path, branch)
 
         -- Check if this is the first worktree, if so switch to it
         local _, count = git.get_worktrees()
-        if count == 1 then
+        if count == 1 or switch == true then
             vim.schedule(function()
                 M.utils.switch_worktree(worktree_path)
             end)


### PR DESCRIPTION
By default the new worktree is activated only if it's the first one.
Added a new parameter that controls whether the newly created worktree
is activated or not. The first worktree is still acticated by default,
the rest aren't unless the parameter is set to `true`.