### PR TITLE
feat: add on_create, on_delete, and on_switch lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
 - Create new Git worktrees with branch creation
 - Delete worktrees with confirmation
 - Switch between worktrees while preserving your place in files
+- Lifecycle hooks for create, delete, and switch events
 - Customizable commands and keymaps
 - Works with any Git worktree structure
 
@@ -55,7 +56,12 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
             create = "<leader>wtc",
             delete = "<leader>wtd",
             switch = "<leader>wts",
-          }
+          },
+
+          -- Lifecycle hooks (optional)
+          on_create = function(path) end,
+          on_delete = function(path) end,
+          on_switch = function(from_path, to_path) end,
     }
 }
 ```
@@ -72,6 +78,9 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
 | `mappings.create` | Key mapping for creating worktrees | `nil` (not set) |
 | `mappings.delete` | Key mapping for deleting worktrees | `nil` (not set) |
 | `mappings.switch` | Key mapping for switching worktrees | `nil` (not set) |
+| `on_create` | Callback `function(path)` called after a worktree is created | `nil` |
+| `on_delete` | Callback `function(path)` called after a worktree is deleted | `nil` |
+| `on_switch` | Callback `function(from_path, to_path)` called after switching worktrees | `nil` |
 
 ### Common Worktree Configurations
 

--- a/doc/worktrees.txt
+++ b/doc/worktrees.txt
@@ -26,6 +26,7 @@ Features:
 - Interactive creation, deletion, and switching of git worktrees
 - Configurable base path and path templates for new worktrees
 - Automatic file correspondence when switching between worktrees
+- Lifecycle hooks for create, delete, and switch events
 - Customizable commands and key mappings
 
 ==============================================================================
@@ -79,6 +80,11 @@ Default configuration: >lua
         -- Use {branch} as placeholder for branch name
         path_template = "{branch}",
 
+        -- Lifecycle hooks (optional)
+        on_create = nil, -- function(path)
+        on_delete = nil, -- function(path)
+        on_switch = nil, -- function(from_path, to_path)
+
         -- Command names for interactive functions
         commands = {
             create = "WorktreeCreate",
@@ -117,6 +123,33 @@ path_template ~
     - "{branch}" - Creates worktree with branch name as directory
     - "wt-{branch}" - Prefixes worktree directories with "wt-"
     - "{branch}-worktree" - Suffixes worktree directories with "-worktree"
+
+                                                     *worktrees-config-on_create*
+on_create ~
+    Type: function|nil
+    Default: nil
+    Signature: function(path)
+
+    Called after a worktree is successfully created. Receives the absolute path
+    of the new worktree.
+
+                                                     *worktrees-config-on_delete*
+on_delete ~
+    Type: function|nil
+    Default: nil
+    Signature: function(path)
+
+    Called after a worktree is successfully deleted. Receives the absolute path
+    of the deleted worktree.
+
+                                                     *worktrees-config-on_switch*
+on_switch ~
+    Type: function|nil
+    Default: nil
+    Signature: function(from_path, to_path)
+
+    Called after a successful worktree switch. Receives the absolute paths of
+    the worktree switched from and the worktree switched to.
 
                                                       *worktrees-config-commands*
 commands ~
@@ -261,5 +294,19 @@ Custom configuration: >lua
         },
     })
 <
+Using lifecycle hooks: >lua
+    require("worktrees").setup({
+        on_create = function(path)
+            print("Created worktree at: " .. path)
+        end,
+        on_delete = function(path)
+            print("Deleted worktree at: " .. path)
+        end,
+        on_switch = function(from_path, to_path)
+            print("Switched from " .. from_path .. " to " .. to_path)
+        end,
+    })
+<
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -44,6 +44,14 @@ Worktrees.config = {
     -- Use {branch} as placeholder for branch name
     path_template = "{branch}",
 
+    -- Lifecycle hooks (optional)
+    -- on_create: called with (path) after a worktree is successfully created
+    on_create = nil,
+    -- on_delete: called with (path) after a worktree is successfully deleted
+    on_delete = nil,
+    -- on_switch: called with (from_path, to_path) after a successful worktree switch
+    on_switch = nil,
+
     -- Command names for interactive functions
     commands = {
         create = "WorktreeCreate",
@@ -71,6 +79,7 @@ Worktrees.utils = {}
 Worktrees.utils.switch_worktree = function(path, change_root)
     if change_root == nil then change_root = true end
 
+    local from_path = vim.fs.normalize(git.get_worktree_root() or "")
     local worktrees = git.get_worktrees()
     if not worktrees or vim.tbl_count(worktrees) == 0 then
         H.notify("No git worktrees found in this repo", vim.log.levels.ERROR)
@@ -128,6 +137,10 @@ Worktrees.utils.switch_worktree = function(path, change_root)
         )
     end
     vim.cmd.clearjumps()
+
+    if Worktrees.config.on_switch then
+        Worktrees.config.on_switch(from_path, normalized_path)
+    end
 
     return true
 end
@@ -193,22 +206,26 @@ Worktrees.utils.create_worktree = function(path, branch, switch)
             vim.log.levels.ERROR
         )
         return nil
-    else
-        H.notify(
-            "Created worktree: " .. branch .. " at " .. worktree_path,
-            vim.log.levels.INFO
-        )
-
-        -- Check if this is the first worktree, if so switch to it
-        local worktrees = git.get_worktrees()
-        if (worktrees and vim.tbl_count(worktrees) == 1) or switch == true then
-            vim.schedule(function()
-                Worktrees.utils.switch_worktree(worktree_path,true)
-            end)
-        end
-
-        return worktree_path
     end
+
+    H.notify(
+        "Created worktree: " .. branch .. " at " .. worktree_path,
+        vim.log.levels.INFO
+    )
+
+    if Worktrees.config.on_create then
+        Worktrees.config.on_create(worktree_path)
+    end
+
+    -- Check if this is the first worktree, if so switch to it
+    local worktrees = git.get_worktrees()
+    if (worktrees and vim.tbl_count(worktrees) == 1) or switch == true then
+        vim.schedule(function()
+            Worktrees.utils.switch_worktree(worktree_path,true)
+        end)
+    end
+
+    return worktree_path
 end
 
 --- Delete a worktree by path
@@ -234,10 +251,15 @@ Worktrees.utils.delete_worktree = function(path)
             vim.log.levels.ERROR
         )
         return false
-    else
-        H.notify("Deleted worktree at: " .. path, vim.log.levels.INFO)
-        return true
     end
+
+    H.notify("Deleted worktree at: " .. path, vim.log.levels.INFO)
+
+    if Worktrees.config.on_delete then
+        Worktrees.config.on_delete(path)
+    end
+
+    return true
 end
 
 -- Interactive UI functions ===================================================
@@ -389,6 +411,11 @@ H.setup_config = function(config)
     H.check_type("mappings.create", config.mappings.create, "string", true)
     H.check_type("mappings.delete", config.mappings.delete, "string", true)
     H.check_type("mappings.switch", config.mappings.switch, "string", true)
+
+    -- Validate callbacks (callable or nil)
+    H.check_type("on_create", config.on_create, "callable", true)
+    H.check_type("on_delete", config.on_delete, "callable", true)
+    H.check_type("on_switch", config.on_switch, "callable", true)
 
     return config
 end

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -79,7 +79,8 @@ Worktrees.utils = {}
 Worktrees.utils.switch_worktree = function(path, change_root)
     if change_root == nil then change_root = true end
 
-    local from_path = vim.fs.normalize(git.get_worktree_root() or "")
+    local worktree_root = git.get_worktree_root()
+    local from_path = worktree_root and vim.fs.normalize(worktree_root) or "(root)"
     local worktrees = git.get_worktrees()
     if not worktrees or vim.tbl_count(worktrees) == 0 then
         H.notify("No git worktrees found in this repo", vim.log.levels.ERROR)
@@ -139,7 +140,9 @@ Worktrees.utils.switch_worktree = function(path, change_root)
     vim.cmd.clearjumps()
 
     if Worktrees.config.on_switch then
-        Worktrees.config.on_switch(from_path, normalized_path)
+        vim.schedule(function()
+            Worktrees.config.on_switch(from_path, normalized_path)
+        end)
     end
 
     return true
@@ -214,7 +217,9 @@ Worktrees.utils.create_worktree = function(path, branch, switch)
     )
 
     if Worktrees.config.on_create then
-        Worktrees.config.on_create(worktree_path)
+        vim.schedule(function()
+            Worktrees.config.on_create(worktree_path)
+        end)
     end
 
     -- Check if this is the first worktree, if so switch to it
@@ -256,7 +261,9 @@ Worktrees.utils.delete_worktree = function(path)
     H.notify("Deleted worktree at: " .. path, vim.log.levels.INFO)
 
     if Worktrees.config.on_delete then
-        Worktrees.config.on_delete(path)
+        vim.schedule(function()
+            Worktrees.config.on_delete(path)
+        end)
     end
 
     return true

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -80,7 +80,7 @@ Worktrees.utils.switch_worktree = function(path, change_root)
     if change_root == nil then change_root = true end
 
     local worktree_root = git.get_worktree_root()
-    local from_path = worktree_root and vim.fs.normalize(worktree_root) or "(root)"
+    local from_path = worktree_root and vim.fs.normalize(worktree_root) or nil
     local worktrees = git.get_worktrees()
     if not worktrees or vim.tbl_count(worktrees) == 0 then
         H.notify("No git worktrees found in this repo", vim.log.levels.ERROR)


### PR DESCRIPTION
## Summary
Add lifecycle hooks: `on_create`, `on_delete`, `on_switch`

Adds optional callback hooks to the setup config that fire after worktree lifecycle events. This is very for automating environment setup that can't be shared across worktrees - e.g. symlinking .env files, running build scripts, e.t.c.

## Usage:
```lua
require("worktrees").setup({
    on_create = function(path)
        -- called after a worktree is created
    end,
    on_delete = function(path)
        -- called after a worktree is deleted
    end,
    on_switch = function(from_path, to_path)
        -- called after switching worktrees
    end,
})
```

## Details:
- All hooks are optional (nil by default)
- on_switch receives the path switched from and the path switched to
- When a newly created worktree is auto-switched to, on_create fires before on_switch
- Documented in both README and vimdoc
