### PR TITLE
feat: allow path_template to accept a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
           -- The common dir is the .git dir in a normal repo or the root dir of a bare repo
           base_path = "..",  -- Parent directory of common dir
           
-          -- Template for worktree folder names
+          -- Template for worktree folder names (string or function(branch) -> path)
           -- This is only used if you don't specify the folder name when creating the worktree
           path_template = "{branch}",  -- Default: use branch name
           
@@ -65,7 +65,7 @@ https://github.com/user-attachments/assets/9873ec7e-4660-4301-9618-82054af3eb1f
 | Option | Description | Default |
 |--------|-------------|---------|
 | `base_path` | Path relative to git common directory where worktrees will be created | `".."` (parent directory) |
-| `path_template` | Template for worktree folder names, `{branch}` is replaced with branch name | `"{branch}"` |
+| `path_template` | Template for worktree folder names (`{branch}` is replaced with branch name), or a `function(branch)` returning a path | `"{branch}"` |
 | `commands.create` | Command name for creating worktrees | `"WorktreeCreate"` |
 | `commands.delete` | Command name for deleting worktrees | `"WorktreeDelete"` |
 | `commands.switch` | Command name for switching worktrees | `"WorktreeSwitch"` |

--- a/doc/worktrees.txt
+++ b/doc/worktrees.txt
@@ -76,7 +76,7 @@ Default configuration: >lua
         base_path = "..",
 
         -- Path template for new worktrees, when one isn't manually provided
-        -- Use {branch} as placeholder for branch name
+        -- Use {branch} as placeholder for branch name, or provide a function(branch) -> path
         path_template = "{branch}",
 
         -- Command names for interactive functions
@@ -108,11 +108,12 @@ base_path ~
 
                                                    *worktrees-config-path_template*
 path_template ~
-    Type: string
+    Type: string|function
     Default: "{branch}"
 
     Template for generating worktree paths when no specific path is provided.
-    Use {branch} as a placeholder for the branch name.
+    Can be a string where {branch} is replaced with the branch name, or a
+    function(branch) that returns a path.
     Examples:
     - "{branch}" - Creates worktree with branch name as directory
     - "wt-{branch}" - Prefixes worktree directories with "wt-"

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -41,7 +41,7 @@ Worktrees.config = {
     base_path = "..",
 
     -- Path template for new worktrees, when one isn't manually provided
-    -- Use {branch} as placeholder for branch name
+    -- Use {branch} as placeholder for branch name, or provide a function(branch) -> path
     path_template = "{branch}",
 
     -- Command names for interactive functions
@@ -164,10 +164,12 @@ Worktrees.utils.create_worktree = function(path, branch, switch)
         end
     else
         -- Use the template to create a path
-        local path_from_template = Worktrees.config.path_template:gsub(
-            "{branch}",
-            branch
-        )
+        local path_from_template
+        if vim.is_callable(Worktrees.config.path_template) then
+            path_from_template = Worktrees.config.path_template(branch)
+        else
+            path_from_template = Worktrees.config.path_template:gsub("{branch}", branch)
+        end
         worktree_path = vim.fs.normalize(
             vim.fn.resolve(vim.fs.joinpath(base_path, path_from_template))
         )
@@ -376,7 +378,9 @@ H.setup_config = function(config)
     config = vim.tbl_deep_extend("force", vim.deepcopy(H.default_config), config or {})
 
     H.check_type("base_path", config.base_path, "string")
-    H.check_type("path_template", config.path_template, "string")
+    if type(config.path_template) ~= "string" and not vim.is_callable(config.path_template) then
+        H.error("`path_template` should be a string or callable, not " .. type(config.path_template))
+    end
     H.check_type("commands", config.commands, "table")
     H.check_type("mappings", config.mappings, "table")
 


### PR DESCRIPTION
## Summary
path_template now accepts a function(branch) returning a path, in addition to the existing string template syntax. This enables dynamic path generation that goes beyond simple string
substitution.

A common pain point with tools like Linear is that their default branch naming includes prefixes that make worktree paths verbose or create unintended subdirectories. For example,
Linear's default format username/ENG-123-issue-title contains a / which would create a nested directory. With a function template, you can normalize these to something clean and
consistent.

## Examples

Strip Linear's username prefix:
```lua
path_template = function(branch)
    return branch:gsub("^[^/]+/", "")
end,
-- "john/ENG-123-fix-login" -> "ENG-123-fix-login"
```

If you only work in one team, strip the team prefix too:
```lua
path_template = function(branch)
    return branch:gsub("^[^/]+/", ""):gsub("^ENG%-", "")
end,
-- "john/ENG-123-fix-login" -> "123-fix-login"
```

## Notes
- Fully backwards compatible — existing string templates continue to work unchanged